### PR TITLE
[BYOI ESXi] Run the test script by default after the image upload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This GitHub repository contains the script files, template files, and documentat
 
 Workflow for Building Image:
 
-![image](https://github.com/hpe-hcss/bmaas-byoi-esxi-build/assets/90067804/a0dc9215-2be7-42bf-b4d0-6ed7f613d3a1)
+![image](https://github.com/HewlettPackard/hpegl-metal-os-esxi-iso/assets/90067804/998aa0e5-2bca-4804-be7c-d12964522204)
 
 Prerequisites:
 ```

--- a/glm-test-service-image.sh
+++ b/glm-test-service-image.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 # (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 
-# This is a script that will verify that the OS image referred to
-# in a corresponding GLM OS service.yml is correct.  This script
-# will verify that it can download the OS image and check its
-# length (in bytes) and signature.  The script simulates what GLM
-# DCC will do when it tries to download and verify an OS image.
-# If this script fail then the service.yml file is most likely
-# broken and will not work if loaded into GLM.
+# This script will verify that the OS image referred to
+# in a corresponding Bare Metal OS service.yml is correct. This script will verify that it can
+# download the OS image and check its length (in bytes) and signature. The script simulates what
+# On-Premises Controller will do when it tries to download and verify an OS image.
+# If this script fails then the service.yml file is most likely broken and will not work
+# if loaded into the HPE Bare Metal Portal.
 
 # Ways to use this script:
 # * glm-test-service-image.sh glm-service.yml
@@ -17,10 +16,10 @@ set -euo pipefail
 # The clean function cleans up any lingering files
 # data that might be present when the script exits.
 clean() {
-    # remove the temp file
-    rm -f $LOCAL_IMAGE_FILENAME
+  rm -f ${LOCAL_IMAGE_FILENAME}
 }
 
+# Set a trap to call the clean function on exit
 trap clean EXIT
 
 usage() {
@@ -29,64 +28,73 @@ script usage: $0 <service.yml>
 EOF
 }
 
-# check command line arguements
-if [[ $# -ne 1 ]]; then
+# check command line arguments
+if [[ $# -lt 1 ]]; then
   echo "bad command line args"
   usage
   exit 1
 fi
 
 # These are the lines that we are interested in from the service.yml file:
-#  secure_url: "http://192.168.1.131/Windows_Server2019_custom-hpe-glm-20230123-29234.tar"
-#  display_url: "Windows_Server2019_custom.iso"
-#  file_size: 5360998400
-#  signature: "750db9d2434faefd1cf2ec1b0f219541b594efa1a99202775e2e6431582ab4bf"
-#  algorithm: sha256sum
-eval $(egrep "file_size:|display_url:|secure_url:|signature:|algorithm:" $* | sed -e "s/^ *//" -e "s/: */=/")
+# For Example:
+#   secure_url: "http://192.168.1.131/VMware-ESXi-7.0u3o-22348816-HPE-703.0.0.11.5.0.6-Jan2024.iso"
+#   display_url: "VMware-ESXi-7.0u3o-22348816-HPE-703.0.0.11.5.0.6-Jan2024"
+#   file_size: 479950848
+#   signature: "4e19d04dcc7defe626657ff808bfd3e6f92e527373cf5bee48348018a2ccb7bc"
+#   algorithm: sha256sum
+eval "$(grep -E "file_size:|display_url:|secure_url:|signature:|algorithm:" "$*" | sed -e "s/^ *//" -e "s/: */=/")"
 
 # Check that required parameters exist.
 # Allow $display_url to be optional.
-if [ -z "$file_size" -o -z "$secure_url" -o \
-     -z "$file_size" -o -z "$algorithm" ]; then
+if [ -z ${file_size} ] || [ -z ${display_url} ] || [ -z ${secure_url} ] || [ -z ${file_size} ] || [ -z ${algorithm} ] || [ -z ${signature} ]; then
   usage
   exit 1
 fi
 
-# print image description that we found
-echo "OS image file to be tested:"
-echo "  Secure URL:" $secure_url
-echo "  Display URL:" $display_url
-echo "  Image size:" $file_size
-echo "  Image signature:" $signature
-echo "  Signature algorithm:" $algorithm
+# print the image description that we found
+echo -e "\nOS image file to be tested:"
+echo "  Secure URL: ${secure_url}"
+echo "  Display URL: ${display_url}"
+echo "  Image size: ${file_size}"
+echo "  Image signature: ${signature}"
+echo "  Signature algorithm: ${algorithm}"
 
 # make sure we have the tool for $algorithm
-which $algorithm > /dev/null 2>&1
+which "$algorithm" > /dev/null 2>&1
 if [ $? -ne 0 ]
 then
-  echo "$algorithm not found. Please install."
-  exit -1
+  echo "ERROR $algorithm not found. Please install."
+  exit 1
 fi
 
 # make temp filename
 LOCAL_IMAGE_FILENAME="$(mktemp /tmp/os-image-XXXXXX.img)"
 
-# download the image
-echo
-echo wget -O $LOCAL_IMAGE_FILENAME $secure_url
-wget -O $LOCAL_IMAGE_FILENAME $secure_url
+# download the image from the source (Web Server, AWS S3, etc)
+# ======================================================================
+# Note: You may use "--no-check-certificate" for Self-signed certificate
+echo -e "\nDownload the image from the source:"
+args=(
+  --no-proxy #optional parameter
+  --no-check-certificate #optional parameter
+)
+DOWNLOAD="wget                                   \
+${args[*]} `#add parameters from the list above` \
+-O ${LOCAL_IMAGE_FILENAME} ${secure_url}"
+echo "$DOWNLOAD"
+$DOWNLOAD
 RC=$?
 if [ $RC -ne 0 ]; then
-    echo "wget failed to download image"
-    exit 1
+  echo "ERROR wget failed to download image"
+  exit 1
 fi
 
-# Verify image file exists.
+# Verify image file exists
 stat ${LOCAL_IMAGE_FILENAME} > /dev/null 2>&1
 RC=$?
 if [ $RC -ne 0 ]; then
-    echo "Image file '${LOCAL_IMAGE_FILENAME}' not found."
-    exit 1
+  echo "ERROR Image file ${LOCAL_IMAGE_FILENAME} not found."
+  exit 1
 fi
 
 # Get file size
@@ -94,22 +102,24 @@ SIZE=$(stat -L -c "%s" "$LOCAL_IMAGE_FILENAME")
 
 # Check file size
 if [ "$SIZE" -ne "$file_size" ]; then
-   echo file size error. expected $file_size got $SIZE
-   exit 1
+  echo "ERROR file size error. expected ${file_size} got ${SIZE}"
+  exit 1
 fi
-echo "Image Size has been verified (" $SIZE "bytes )"
+echo "Test 1: Image size has been verified ( ${SIZE} bytes )"
 
 # Calculate checksum
 SUM=$($algorithm $LOCAL_IMAGE_FILENAME | sed "s/ .*//")
 
+echo
 # Check checksum
 if [ "$SUM" != "$signature" ]; then
-   echo file checksum error. expected $signature got $SUM
-   exit 1
+  echo "ERROR file checksum error. expected ${signature} got ${SUM}"
+  exit 1
 fi
-echo "Image Signature has been verified (" $SUM ")"
+echo "Test 2: Image signature has been verified ( ${SUM} )"
 
 # success
-echo The OS image size and signature have been verified
+echo "SUCCESS! The OS image size and signature have been verified"
 
+# remove the temp file
 clean


### PR DESCRIPTION
Pushing the latest changes from bmaas-byoi-esxi-build [PR #7]
--
[BYOI ESXi] Run the test script by default after the image upload.

For Manual Build: File: glm-build-image-and-service.sh
<1> Add an optional parameter SKIP_TEST and a function run_test to run/skip the test script glm-test-service-image.sh the image upload.
<2> User to fill in WEB SERVER-related parameters to use Web Server as a source of images.

For CircleCI Build: File: build-image.sh
<1> Add an optional parameter SKIP_TEST and a function run_test to run/skip the test script glm-test-service-image.sh the image upload.

File: README.md
<1> Update documentation related to glm-build-image-and-service.sh having new parameter -x <skip-test> and remove details about glm-test-service-image.sh.
<2> Update the section "Known Observations and Limitations" about "Host readiness for the user to log in"
<3> File Hosting.md entry in the table of all files.

File: glm-test-service-image.sh
<1> Optimized/simplified this test script
